### PR TITLE
feat: removal of unavailable peers

### DIFF
--- a/node/peerdiscovery_test.go
+++ b/node/peerdiscovery_test.go
@@ -52,3 +52,40 @@ func TestPeerDiscovery(t *testing.T) {
     t.Errorf("bootstrap address %v is not in node known peers", bootAddr)
   }
 }
+
+func TestRemovalOfUnhealthyPeer(t *testing.T) {
+  wg := new(sync.WaitGroup)
+  // Create the peer discovery without staring for the bootstrap node
+  bootPeerDisc := createPeerDiscovery(t.Context(), wg, true, false)
+  // Start the gRPC server on the bootstrap node
+  waitForPeersDiscovery := make(chan struct{})
+  grpcStartSvr(t, bootAddr, func(grpcSrv *grpc.Server) {
+    node := rpc.NewNodeSrv(bootPeerDisc, nil)
+    rpc.RegisterNodeServer(grpcSrv, node)
+
+    go func() {
+      <-waitForPeersDiscovery
+      grpcSrv.Stop()
+    }()
+  })
+  // Create and start the peer discovery for the new node
+  nodePeerDisc := createPeerDiscovery(t.Context(), wg, false, true)
+  // Wait for the peer discovery to discover peers
+  time.Sleep(150 * time.Millisecond)
+  // Verify that the bootstrap node and the new node have discovered each other
+
+  if !slices.Contains(bootPeerDisc.Peers(), nodeAddr) {
+    t.Errorf("node address %v is not in bootstrap known peers", nodeAddr)
+  }
+  if !slices.Contains(nodePeerDisc.Peers(), bootAddr) {
+    t.Errorf("bootstrap address %v is not in node known peers", bootAddr)
+  }
+
+  waitForPeersDiscovery <- struct{}{}
+  // Wait for the peer discovery to try to discover peers
+  time.Sleep(250 * time.Millisecond)
+
+  if len(nodePeerDisc.Peers()) != 0 {
+    t.Errorf("node peer discovery should not have any peers after the bootstrap node is stopped")
+  }
+}


### PR DESCRIPTION
When any of the registered peers is unavailable remove it from the list

Related to: https://github.com/volodymyrprokopyuk/go-blockchain/issues/3

---
Peers registration / removal is not concurrent safe - I've kept it as it is to do not overcomplicate it
I've decreased peer discovery interval in test - as sometimes peerdiscovery test were not passed. (It can be solved with upcoming synctest in go 1.25)